### PR TITLE
에러코드 status 수정 및 gridfs-stream 라이브러리를 사용하기 위한 GridFS 스트림 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Report_Nodejs_Lv1-2",
+  "name": "hanghae_toyproject",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,8 +7,10 @@
       "dependencies": {
         "cookie-parser": "^1.4.6",
         "express": "^4.18.2",
+        "gridfs-stream": "^1.1.1",
         "jsonwebtoken": "^9.0.0",
-        "mongoose": "^7.0.4",
+        "mongodb": "^5.4.0",
+        "mongoose": "^7.1.0",
         "nodemon": "^2.0.22",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^4.6.2"
@@ -454,6 +456,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/flushwritable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flushwritable/-/flushwritable-1.0.0.tgz",
+      "integrity": "sha512-3VELfuWCLVzt5d2Gblk8qcqFro6nuwvxwMzHaENVDHI7rxcBRtMCwTk/E9FXcgh+82DSpavPNDueA9+RxXJoFg=="
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -534,6 +541,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/gridfs-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gridfs-stream/-/gridfs-stream-1.1.1.tgz",
+      "integrity": "sha512-EcELdPIjC7tpZUiZA/8trfmszLbcsZlFyDQ8DhMtyJIMDmuLi5Vzt/056OO6FqfvY/zwiTCo1eZAqwtqrhBGMQ==",
+      "dependencies": {
+        "flushwritable": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4.2"
       }
     },
     "node_modules/has": {
@@ -820,11 +838,11 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.1.0.tgz",
-      "integrity": "sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.4.0.tgz",
+      "integrity": "sha512-6GDKgO7WiYUw+ILap143VXfAou06hjxDGgYUZWGnI4hgoZfP3el0G3l69JqJF8SEQbZmC+SN/2a0aWI/aWJoxA==",
       "dependencies": {
-        "bson": "^5.0.1",
+        "bson": "^5.2.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -836,7 +854,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.201.0",
-        "mongodb-client-encryption": "^2.3.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
         "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
@@ -861,13 +879,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.0.4.tgz",
-      "integrity": "sha512-MEmQOOqQUvW1PJcji64NtA2EFGHrEvk9o4g//isVYSJW2+8Y8u49C2qFBKzn1t6/l9onQn012o/PcFqR6ixQpQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.1.0.tgz",
+      "integrity": "sha512-shoo9z/7o96Ojx69wpJn65+EC+Mt3q1SWTducW+F2Y4ieCXo0lZwpCZedgC841MIvJ7V8o6gmzoN1NfcnOTOuw==",
       "dependencies": {
-        "bson": "^5.0.1",
+        "bson": "^5.2.0",
         "kareem": "2.5.1",
-        "mongodb": "5.1.0",
+        "mongodb": "5.3.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -879,6 +897,38 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.3.0.tgz",
+      "integrity": "sha512-Wy/sbahguL8c3TXQWXmuBabiLD+iVmz+tOgQf+FwkCjhUIorqbAxRbbz00g4ZoN4sXIPwpAlTANMaGRjGGTikQ==",
+      "dependencies": {
+        "bson": "^5.2.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.201.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
       }
     },
     "node_modules/mongoose/node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "dependencies": {
     "cookie-parser": "^1.4.6",
     "express": "^4.18.2",
+    "gridfs-stream": "^1.1.1",
     "jsonwebtoken": "^9.0.0",
-    "mongoose": "^7.0.4",
+    "mongodb": "^5.4.0",
+    "mongoose": "^7.1.0",
     "nodemon": "^2.0.22",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.2"

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -54,7 +54,7 @@ router.get('/:postId/comments', async(req, res) => {
         res.json({ "data" : results })
     } catch (err) {
         console.log(err);
-        res.status(400).send({ message: '데이터 형식이 올바르지 않습니다.' });
+        res.status(416).send({ message: '데이터 형식이 올바르지 않습니다.' });
     }
 })
 
@@ -91,7 +91,7 @@ router.put('/:postId/comments/:commentId', authMiddleware, async(req, res) => {
         }
     } catch (err) {
         console.log(err);
-        res.status(400).send({ message: '댓글 수정에 실패하였습니다.' });
+        res.status(415).send({ message: '댓글 수정에 실패하였습니다.' });
     }
 });
 
@@ -128,7 +128,7 @@ router.delete('/:postId/comments/:commentId', authMiddleware, async(req, res) =>
         }
     } catch (err) {
         console.log(err);
-        res.status(400).send({ message: '댓글 삭제에 실패하였습니다.' });
+        res.status(415).send({ message: '댓글 삭제에 실패하였습니다.' });
     }
 });
 

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -15,14 +15,14 @@ router.post('/:postId/comments', authMiddleware, async (req, res) => {
         if ((req.body.comment).length > 0) {
             comment = req.body.comment;
         } else if ((req.body.comment).length === 0){
-            return res.status(412).json({ errorMessage: "댓글 내용을 입력해주세요."}); 
+            return res.status(410).json({ errorMessage: "댓글 내용을 입력해주세요."}); 
         } else {
-            return res.status(412).json({ errorMessage: "데이터 형식이 올바르지 않습니다."}); 
+            return res.status(410).json({ errorMessage: "데이터 형식이 올바르지 않습니다."}); 
         };
 
         const existPost = await Posts.findOne({ _id: postId });
         if (!existPost) {
-            return res.status(404).json({ errorMessage: '게시글이 존재하지 않습니다.' });
+            return res.status(412).json({ errorMessage: '게시글이 존재하지 않습니다.' });
         };
 
         await Comments.create({ postId, userId, nickname, comment });
@@ -67,19 +67,19 @@ router.put('/:postId/comments/:commentId', authMiddleware, async(req, res) => {
 
         const existPost = await Posts.findOne({_id: postId});
         if (!existPost) {
-            return res.status(404).json({ errorMessage: '게시글이 존재하지 않습니다.' });
+            return res.status(412).json({ errorMessage: '게시글이 존재하지 않습니다.' });
         }
         
         const existComment = await Comments.findOne({ _id:commentId });
         if (!existComment) {
-            return res.status(404).json({ errorMessage: '댓글이 존재하지 않습니다.' });
+            return res.status(412).json({ errorMessage: '댓글이 존재하지 않습니다.' });
         }
 
         let comment;
         if ((req.body.comment).length > 0) {
             comment = req.body.comment;
         } else {
-            return res.status(412).json({ errorMessage: "데이터 형식이 올바르지 않습니다."}); 
+            return res.status(410).json({ errorMessage: "데이터 형식이 올바르지 않습니다."}); 
         };
 
         if (userId === existComment.userId) {
@@ -87,7 +87,7 @@ router.put('/:postId/comments/:commentId', authMiddleware, async(req, res) => {
             await Comments.updateOne({_id:commentId}, { $set: { comment, updatedAt }});
             return res.status(201).json({ message: '댓글을 수정하였습니다.' });
         } else {
-            return res.status(403).json({ errorMessage: '댓글의 수정 권한이 존재하지 않습니다.' });
+            return res.status(414).json({ errorMessage: '댓글의 수정 권한이 존재하지 않습니다.' });
         }
     } catch (err) {
         console.log(err);
@@ -104,19 +104,19 @@ router.delete('/:postId/comments/:commentId', authMiddleware, async(req, res) =>
 
         const existPost = await Posts.findOne({_id: postId});
         if (!existPost) {
-            return res.status(404).json({ errorMessage: '게시글이 존재하지 않습니다.' });
+            return res.status(412).json({ errorMessage: '게시글이 존재하지 않습니다.' });
         }
         
         const existComment = await Comments.findOne({ _id:commentId });
         if (!existComment) {
-            return res.status(404).json({ errorMessage: '댓글이 존재하지 않습니다.' });
+            return res.status(412).json({ errorMessage: '댓글이 존재하지 않습니다.' });
         }
 
         let comment;
         if ((req.body.comment).length > 0) {
             comment = req.body.comment;
         } else {
-            return res.status(412).json({ errorMessage: "데이터 형식이 올바르지 않습니다."}); 
+            return res.status(410).json({ errorMessage: "데이터 형식이 올바르지 않습니다."}); 
         };
 
         if (userId === existComment.userId) {
@@ -124,7 +124,7 @@ router.delete('/:postId/comments/:commentId', authMiddleware, async(req, res) =>
             await Comments.deleteOne({_id:commentId});
             return res.status(201).json({ message: '댓글을 삭제하였습니다.' });
         } else {
-            return res.status(403).json({ errorMessage: '댓글의 삭제 권한이 존재하지 않습니다.' });
+            return res.status(414).json({ errorMessage: '댓글의 삭제 권한이 존재하지 않습니다.' });
         }
     } catch (err) {
         console.log(err);

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -2,6 +2,9 @@ const express = require('express');
 const router = express.Router();
 const authMiddleware = require("../middlewares/auth-middleware.js");
 const Posts = require('../schemas/post.js');
+const Grid = require('gridfs-stream');
+Grid.mongo = mongoose.mongo;
+const gfs = Grid(db, mongoose.mongo);
 
 
 // 게시글 생성 : POST -> localhost:3000/posts
@@ -12,7 +15,7 @@ router.post('/', authMiddleware, async (req, res) => {
         await Posts.create({ userId, nickname, title, content });
         return res.status(200).json({ message: '게시글 작성에 성공하였습니다.' })
     } catch {
-        return res.status(400).json({ message: '데이터 형식이 올바르지 않습니다.' });
+        return res.status(416).json({ message: '데이터 형식이 올바르지 않습니다.' });
     }
 });
 
@@ -76,17 +79,17 @@ router.put('/:postId', authMiddleware, async (req, res) => {
         const [post] = await Posts.find({ _id: postId });
         
         if (title.length===0) {
-            return res.status(412).json({ errorMessage: "게시글 제목의 형식이 일치하지 않습니다."})
+            return res.status(410).json({ errorMessage: "게시글 제목의 형식이 일치하지 않습니다."})
         }
         if (content.length===0) {
-            return res.status(412).json({ errorMessage: "게시글 내용의 형식이 일치하지 않습니다."})
+            return res.status(410).json({ errorMessage: "게시글 내용의 형식이 일치하지 않습니다."})
         }
         if (userId === post.userId) {
             const date = new Date();
             await Posts.updateOne({ _id: postId }, { $set: { title: title, content: content, updatedAt: date } })
             return res.status(200).json({ message: '게시글을 수정하였습니다.' });
         } else {
-            return res.status(403).json({ errorMessage: '게시글 수정의 권한이 존재하지 않습니다.' });
+            return res.status(414).json({ errorMessage: '게시글 수정의 권한이 존재하지 않습니다.' });
         }
     } catch (err) {
         console.error(err);
@@ -104,18 +107,18 @@ router.delete('/:postId', authMiddleware, async (req, res) => {
         const post = await Posts.findOne({ _id: postId });
 
         if (!post) {
-            return res.status(404).json({ message: '게시글이 존재하지 않습니다.' });
+            return res.status(412).json({ message: '게시글이 존재하지 않습니다.' });
         }
         
         if (userId === post.userId) {
             await Posts.deleteOne({ _id: postId })
             return res.status(200).json({ message: '게시글을 삭제하였습니다.' });
         } else {
-            return res.status(403).json({ errorMessage: '게시글의 삭제 권한이 존재하지 않습니다.' });
+            return res.status(414).json({ errorMessage: '게시글의 삭제 권한이 존재하지 않습니다.' });
         }
     } catch (err) {
         console.error(err);
-        return res.status(400).send({ errorMessage: '게시글 삭제에 실패하였습니다.' });
+        return res.status(415).send({ errorMessage: '게시글 삭제에 실패하였습니다.' });
     }
 });
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -11,7 +11,7 @@ router.post('/signup', async (req, res) => {
 
    // 패스워드, 확인패스워드 일치 검증
    if (password !== confirm) {
-      res.status(412).json({
+      res.status(410).json({
          errorMessage: "패스워드가 일치하지 않습니다."
       });
       return;  // 패스워드 검증이 실패하면 뒤에는 실행시키지 않도록 return으로 브레이크
@@ -19,7 +19,7 @@ router.post('/signup', async (req, res) => {
 
    // 패스워드 닉네임을 포함시키면 에러메세지
    if (password.includes(nickname)) {
-      res.status(412).json({
+      res.status(410).json({
          errorMessage: "패스워드에 닉네임이 포함되어 있습니다."
       });
       return;
@@ -27,7 +27,7 @@ router.post('/signup', async (req, res) => {
 
    // 패스워드 4글자 이하이면 에러메세지 
    if (password.length <= 4) {
-      res.status(412).json({
+      res.status(410).json({
          errorMessage: "패스워드 형식이 일치하지 않습니다."
       });
       return;
@@ -37,7 +37,7 @@ router.post('/signup', async (req, res) => {
    // 닉네임 DB 중복 검증
    const isExistuser = await UserSchema.findOne({ nickname });
    if (isExistuser) {
-      res.status(412).json({
+      res.status(410).json({
          errorMessage: "중복된 닉네임입니다."
       });
       return;
@@ -45,7 +45,7 @@ router.post('/signup', async (req, res) => {
 
    // 닉네임 최소 3글자 이상, 알파벳 대소문자, 숫자 외 에러메세지
    if ((!/^[a-zA-Z0-9]+$/.test(nickname)) || (nickname.length < 4)) {
-      res.status(412).json({
+      res.status(410).json({
          errorMessage: "닉네임의 형식이 일치하지 않습니다."
       });
       return;
@@ -71,7 +71,7 @@ router.post('/login', async (req, res) => {
       // 1. 이메일에 일치하는 유저가 존재하지 않거나
       // 2. 유저를 찾았지만, 유저의 비밀번호와 입력한 비밀번호가 다를 때
       if (!user || user.password !== password) {
-         res.status(412).json({ errorMessage: "닉네임 또는 패스워드를 확인해주세요." });
+         res.status(410).json({ errorMessage: "닉네임 또는 패스워드를 확인해주세요." });
          return;  // 다음코드로 진행되지 않도록 막을거다.
       };
 


### PR DESCRIPTION
410 : 유효성 검사 에러(형식이 일치하지 않는)
411 : 데이터 불일치(비밀번호 등)
412 : 데이터가 존재하지 않음
413 : 쿠키, 세션에서 발생한 오류
414 : 권한이 존재하지 않음
415 : 삭제 및 생성 등이 실패한 경우
416 : 데이터 전달 에러(형식 등)
400 : 예외 케이스

GridFS는 몽고db에서 지원하는 데이터모델로 사용하기 위해서는 npm install gridfs-stream 명령어를 통해 라이브러리를 설치해줘야 합니다.

다음 형식을 지켜서 에러코드의 status 를 수정하고,gridfs-stream 라이브러리를 사용하기 위해 GridFS 스트림을 생성했습니다.