### PR TITLE
프론트엔드와 소통하여 허용하는 파일 사이즈를 25MB 까지 늘리고,

### DIFF
--- a/modules/s3.js
+++ b/modules/s3.js
@@ -44,8 +44,8 @@ const uploadImage = multer({
         acl        : 'public-read'
     }),
     limits: {
-        fileSize: 5 * 1024 * 1024
+        fileSize: 25 * 1024 * 1024
     }
-});
+}); 
 
 module.exports = uploadImage;

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -60,7 +60,8 @@ router.get('/:postId', async (req, res) => {
             title: post.title,
             content: post.content,
             createdAt: post.createdAt,
-            updatedAt: post.updatedAt
+            updatedAt: post.updatedAt,
+            photo_ip: post.photo_ip,
         };
         res.json({ data: result });
     } catch (err) {


### PR DESCRIPTION
기본 get 요청에 post_ip를 포함하여 리퀘스트 하도록 수정했습니다